### PR TITLE
let me amp it up a little 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Patapon 3 Overhaul Wiki
+## Pages
+
+Pages are found in [this folder](https://github.com/p3o-wiki/p3o-wiki.github.io/tree/main/src/routes/pages). To make a new page, create a markdown file (ending with .md). Those files use syntax described below.
 
 ## Syntax
 

--- a/src/routes/pages/equipment_rarities.md
+++ b/src/routes/pages/equipment_rarities.md
@@ -4,8 +4,6 @@ category: Miscellaneous
 ord: 10000
 ---
 
-# Equipment Rarities and Chests
-
 Chests can have different rarities. Better the rarity is, the better equipment it is.
 
 ## Chest Tiers

--- a/src/routes/pages/equipment_rarities.md
+++ b/src/routes/pages/equipment_rarities.md
@@ -5,34 +5,54 @@ ord: 10000
 ---
 
 # Equipment Rarities and Chests
+
 Chests can have different rarities. Better the rarity is, the better equipment it is.
+
 ## Chest Tiers
+
 - Wooden
 - Silver
 - Golden
 - Jewel
 - Pink Jewel
-Pink Jeweled can be found in Multiplayer Dungeons (ex. Depths of Rage, Depths of Jealousy).
+  Pink Jeweled can be found in Multiplayer Dungeons (ex. Depths of Rage, Depths of Jealousy).
+
 ## Equipment Tiers
+
 ### Common
+
 Upgradeable. They have no special properties. Maximum drop level is your current max level. Usually drops from Wooden chests.
+
 ### Enchanted
+
 Upgradeable. Enchants will affect your stats Maximum drop level is up to half of your current max level (up to +50) but can be upgraded to +100. Usually drops from Silver chests.
+
 ### Unique
+
 Not upgradeable. Every item has special stats that define it. Maximum level is 64% of your current max level (max. +64). Usually drops from Golden chests.
+
 ### Super Unique
+
 Not upgradeable. Most likely stronger than Unique but not always, may affect your stats in a way you don't like. Maximum level is 52% of your current max level (max. +52). Usually drops from Jeweled and **Pink Jeweled** chests.
+
 ### Ultimate
+
 Drops with very a low chance from **Pink Jeweled** chests, the higher the chest level the higher the chance! Will always be the best equipment.
+
 ### Relics
+
 New items with special powers! Can be found at the end of some floors or quests. Can't be found in chests.
+
 ## Tips
+
 - Common items will be your highest level equipment until you put in extra work, they'll also be your best source of ka-ching.
 - Different classes benefit from different enchants, on some they might be great and on others useless
 - Upgrading enchanted equipment will be costly if you try to keep up with your level, don't use too many at once.
 - Finding good chests can be a hustle, increasing quest levels will result in higher level chest (with few exceptions).
 - Most equipment tiers can be found in any chest tier (with exceptions) with a very low chance (some rarer than others).
+
 ### Notes
+
 - Gargoyles may hold any chest tier except for Pink Jeweled.
 - Every Multiplayer Dungeon has it's own chance for a Pink Jeweled chest to appear.
 - Obtaining Unique and Super Unique items with levels higher than designed is possible but they're not permanent.

--- a/src/routes/pages/stews.md
+++ b/src/routes/pages/stews.md
@@ -1,5 +1,5 @@
 ---
-title: Materials
+title: Stews
 category: Items
 ord: 1000000
 ---

--- a/src/routes/pages/stews.md
+++ b/src/routes/pages/stews.md
@@ -4,8 +4,6 @@ category: Items
 ord: 1000000
 ---
 
-# Stews
-
 ## Gruel stew
 
 Doubles picked up Ka-Ching.

--- a/src/routes/pages/stews.md
+++ b/src/routes/pages/stews.md
@@ -3,18 +3,33 @@ title: Materials
 category: Items
 ord: 1000000
 ---
+
 # Stews
+
 ## Gruel stew
+
 Doubles picked up Ka-Ching.
+
 ## Tasty stew
+
 Quest gains 5 levels upon completion (only works for quest levels 10-85).
+
 ## King's stew
+
 Allows the host to control the Boss (multiplayer only).
+
 ## Divine stew
+
 Doubles Level and Class Skill XP gain.
+
 ## Demon stew
+
 Doubles Chests, Materials and Keys.
+
 ## Glitch stew
+
 Randomizes quest spawns, but keeps the layout (ex: if the building spawns a miniboss, it will randomize what Miniboss it will spawn at the quest).
+
 ## Ancient stew
+
 Swaps Pons with Heroes.

--- a/src/routes/pages/weapons.md
+++ b/src/routes/pages/weapons.md
@@ -1,5 +1,5 @@
 ---
-title: Materials
+title: Weapons
 category: Items
 ord: 100
 ---


### PR DESCRIPTION
For example

ord: 10000
---

# Equipment Rarities and Chests
Chests can have different rarities. The higher the rarity, the better equipment!

## Chest Tiers

- Wooden
The lowest of the low, but don't count them out! More common than dirt but can still drop enchanted and high level basic equipment!
- Silver
Silver Chests are a bit less common than Wooden Chests and commonly drop enchanted equipment! They're found just about everywhere.
- Golden
Golden Chests although less common than Silver Chest, are still found in many places and tend to drop Unique equipment! 
- Jewel
Jeweled Chests although more uncommon than Golden Chests can be found in many places in your journey still! Including solo and multiplayer dungeons! Maybe a certain lucky star might have some for you later?
- Pink Jewel
Pink Jeweled Chests the zenith of all chests are to be found in Multiplayer Dungeons! (ex. Depths of Rage, Depths of Jealousy).
  Getting one of these is always a sight to behold! Happy hunting!

## Equipment Tiers

### Common

Upgradeable. Yet they have no special properties. Maximum drop level is your current max level. These usually drops from Wooden chests.

### Enchanted

Upgradeable. Enchants will effect your stats in various fashions! Maximum drop level is up to half of your current max level (up to +50) but can be upgraded to +100. They usually drops from Silver Chests.

### Unique

Non-upgradeable. Every "Unique" item has special stats that define them. Maximum level is 64% of your current max level (max. +64). Usually drops from Golden chests.

### Super Unique

Non-upgradeable. Tend to be stronger than Uniques but mileage may vary. Tend to effect your stats in unsuspected ways for better and or for worse! Maximum level is 52% of your current max level (max. +52). Usually drops from Jeweled and **Pink Jeweled** chests.

### Ultimate

Drops with very a low chance from **Pink Jeweled** chests, the higher the chest level the higher the chance! These items are a cut above and are considered the pinnacle of the Patapon Arsenal!

### Relics

New equipment with unique attributes surging with ancient power! Relics be found at the end of some floors or quests. or miniboss monsters and certain structures.  (Relics CAN NOT be found in chests)

## Tips

- Common items will usually be your highest level equipment until you level your items with the blacksmith, they'll also be one of your best sources of Ka-Ching.
- Different classes benefit from different enchants, on some they might be great and on others useless
- Upgrading enchanted equipment will be costly if you try to keep up with your level, don't use too many at once.
- Finding good chests can be a hustle, increasing quest levels will result in higher level chest (with few exceptions).
- Most equipment tiers can be found in any chest tier (with exceptions) with a very low chance (some rarer than others).

### Notes

- Gargoyles may hold any chest tier barring Pink Jeweled.
- Every Multiplayer Dungeon has it's own chance for a Pink Jeweled chest to appear.
- Obtaining Unique and Super Unique items with levels higher than designed is possible but they're not permanent.
15 changes: 14 additions & 1 deletion 15
[src/routes/pages/stews.md](https://github.com/Wegwey/p3o-wiki.github.io/compare/patch-1...main#diff-deee245db23ad277ce74bcc202694d9b2e0d88a95a7e2bb6ae7904c6155c1ad1)
@@ -3,18 +3,31 @@ title: Materials
category: Items
ord: 1000000
---
# Stews

## Gruel stew

This questionable consumable doubles all picked up Ka-Ching! 

## Tasty stew

Quests gain 5 levels upon completion!  (Only works until quest level 85 and will not overflow. For example Tasty stew into level 81 would not get you to 86).

## King's stew

Allows the host to control a multiplayer map Boss! (DOES NOT WORK IN SOLO GAMES)

## Divine stew

Doubles Level and Class Skill XP gain. Stacks with other effects!

## Demon stew

Doubles ALL picked up items excluding relic drops. More twigs! More Chests! MORE FUN!

## Glitch stew

Randomizes quest spawns but not the map layout (ex: if the building spawns a miniboss, it will randomize what Miniboss it will spawn at the quest). boosts EXP when used!

## Ancient stew

Converts basic Patapons into MIGHTY Uberheroes and vice versa! (Works in multiplayer and versus)